### PR TITLE
Add versioning strategy document

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,101 @@
+# Versioning
+
+This document describes the versioning strategy for the kpt project.
+
+## Semantic Versioning (SemVer)
+
+We use [semantic versioning](https://semver.org/) for all release artifacts.
+Releases with a fully specified version (e.g. `vX.Y.Z`) are immutable and will
+never be changed.
+
+## Floating Tags
+
+We support abbreviated SemVer tags as floating tags:
+
+- `v<major>.<minor>` always points to the latest patch release within that
+  minor version. For example, `v1.2` initially points to `v1.2.0`. After
+  `v1.2.1` is released, `v1.2` is updated to point to `v1.2.1`.
+
+- `v<major>` always points to the latest release within that major version.
+  For example, `v1` initially points to `v1.2.0`. After `v1.3.0` is released,
+  `v1` is updated to point to `v1.3.0`.
+
+These floating tags apply to container images and CLI binaries. If Go modules are
+published, they use fully specified versions (`vX.Y.Z`) and do not use floating tags.
+
+## Latest Tag
+
+The `latest` tag is supported on all container images and points to the most
+recent release. However, it provides no compatibility or stability guarantee.
+The `latest` tag should only be used for testing and development, not in
+production environments.
+
+## Breaking Changes
+
+We define a breaking change as: for any given valid input, the software produces
+a different result on a user-facing surface, or a previously supported input is
+no longer accepted.
+
+## Backwards Compatibility
+
+For versions v1.0.0 and later:
+
+- **Major version bump**: breaking major changes that require a Go module import path
+  change (e.g. `module/v2`).
+- **Minor version bump**: may contain breaking changes, new features, or
+  improvements.
+- **Patch version bump**: bug fixes and security fixes only.
+
+For pre v1.0.0 versions (major version is always `0`):
+
+- **Minor version bump**: may contain breaking changes. SemVer allows breaking
+  changes at any time before v1.0.0. Additionally, Go modules require major
+  versions v2+ to use a different import path (for example, `module/v2`). While
+  a major version bump is the conventional way to signal a breaking change for
+  stable (v1+) APIs, bumping from v0 to v1 would indicate that the API is now
+  stable, which we are not yet ready to do. Therefore, during the v0.x phase,
+  breaking changes are communicated through minor version bumps instead.
+- **Patch version bump**: bug fixes, security fixes, and backward-compatible
+  features.
+
+Pre-release versions (e.g. `v1.0.0-beta.N`) are unstable and may contain
+breaking changes between any two releases.
+
+## Compatibility Rules
+
+The following rules apply within a major version (i.e. non-breaking changes
+must not violate these):
+
+### Packages
+
+- Package format MUST NOT change
+- Optional fields MAY be added
+
+### Command Line
+
+- Subcommands MUST NOT be removed
+- Subcommands SHOULD NOT change in meaning
+- Command line flags MUST NOT be deleted
+- Command line flags SHOULD NOT change in meaning
+
+### Code
+
+- Existing behaviors MUST NOT change
+
+### Compatibility with Kubernetes
+
+The compatibility policy with specific Kubernetes versions is not yet defined.
+Until this section is formalized, refer to each repository's release notes for
+supported Kubernetes versions.
+
+During a major release, all code is subject to revision, but package backward
+compatibility SHOULD be retained.
+
+## Best Practices
+
+- Pin the full semantic version (`vX.Y.Z`) in CI and production for
+  deterministic, reproducible builds.
+- Use floating tags (`vX.Y`, `vX`) when you want to automatically receive
+  security and bug fixes with less maintenance overhead.
+- Avoid using the `latest` tag in production.
+- Read release notes before upgrading, especially across minor versions.

--- a/release-handling.md
+++ b/release-handling.md
@@ -4,28 +4,8 @@ This is currently a work-in-progress, based on ongoing discussions in the kpt de
 
 ### Semantic Versioning
 
-We follow semantic versioning. This can mean we have to reject non-backward-compatible changes until
-a breaking release in order to preserve backward compatibility.
-
-For kpt this means:
-
-Packages:
-* Package format MUST NOT change
-* Optional fields can be added
-
-Command line:
-* Subcommands MUST NOT be removed
-* Subcommands SHOULD NOT change in meaning
-* Command line flags MUST NOT be deleted
-* Command line flags SHOULD NOT change in meaning
-
-Code: 
-* Existing behaviours MUST NOT change
-
-Compatibility with Kubernetes:
-TBD
-
-During a major release, all code is subject to revision, but package backward compatibility SHOULD be retained.
+We follow semantic versioning. See [VERSIONING.md](VERSIONING.md) for the full versioning strategy,
+including compatibility rules, floating tags, and breaking change definitions.
 
 ### Issue Triaging
 
@@ -63,7 +43,7 @@ A PR can only be merged only if:
 
 Corresponding to SemVer, we have three different types of release:
 * Major: 1.0.0, 2.0.0, etc. Breaks compatibility with previous releases.
-* Minor: 2.1.0, 2.2.0, etc. Maintains compatibility per our SemVer rules above, but may add new features, fix bugs.
+* Minor: 2.1.0, 2.2.0, etc. Maintains compatibility per our [versioning rules](VERSIONING.md), but may add new features, fix bugs.
 * Patch: 2.1.1, 2.1.2, etc. Maintains compatibility, adds no features, but fixes bugs.
 
 Major releases and Minor releases are done by tagging *main* with the version number, and then running the release scripts (TBD).


### PR DESCRIPTION
## Description
  - **What changed**: Added `VERSIONING.md` as the single source of truth for the kpt project's versioning strategy. Moved the compatibility rules (packages, CLI, code) from `release-handling.md` into `VERSIONING.md` and replaced the duplicated section with a link.
  - **Why it's needed**: The SemVer compatibility rules were partially duplicated between `release-handling.md` and the new `VERSIONING.md`. Consolidating them avoids divergence and gives consumers a single document covering versioning semantics, floating tags, and compatibility guarantees.
  - **How it works**: `VERSIONING.md` now covers the full versioning strategy (SemVer, floating tags, `latest` tag, breaking changes definition, backwards compatibility policy, and compatibility rules). `release-handling.md` focuses on the release *process* and links to `VERSIONING.md` for version semantics.

  ## Related Issue(s)

  - Part of https://github.com/kptdev/kpt/issues/4621

  ## Type of Change

  - [x] Documentation

  ## Checklist

  - [x] Self-reviewed changes
  - [x] Documentation added/updated

  ## Additional Notes

  - `VERSIONING.md` is a new file; `release-handling.md` is updated to remove the duplicated compatibility rules and link to the new document instead.

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to draft `VERSIONING.md` content and consolidate the duplicated sections.